### PR TITLE
Win64 size_t changes applied to reaction class definitions.

### DIFF
--- a/src/AssociationReaction.h
+++ b/src/AssociationReaction.h
@@ -70,13 +70,13 @@ namespace mesmer
     };
 
     // Get product information:
-    virtual int get_products(std::vector<Molecule*>& unimolecularspecies) const
+    virtual size_t get_products(std::vector<Molecule*>& unimolecularspecies) const
     {
       unimolecularspecies.push_back(m_pdt1);
       return 1;
     };
 
-    virtual int get_reactants(std::vector<Molecule*>& reactants) const
+    virtual size_t get_reactants(std::vector<Molecule*>& reactants) const
     {
       reactants.push_back(m_rct1);
       reactants.push_back(m_rct2);

--- a/src/BimolecularSinkReaction.h
+++ b/src/BimolecularSinkReaction.h
@@ -56,7 +56,7 @@ namespace mesmer
     virtual double get_relative_TSZPE()  const { return m_TransitionState->getDOS().get_zpe() - getEnv().EMin; }
 
     // Return products - copied from IrreversibleUnimolecular rxn
-    virtual int get_products(std::vector<Molecule *> &product) const
+    virtual size_t get_products(std::vector<Molecule *> &product) const
     {
       product.push_back(m_pdt1) ;
       if(m_pdt2){
@@ -70,7 +70,7 @@ namespace mesmer
       return 1;
     } ;
 
-    virtual int get_reactants(std::vector<Molecule *> &reactants) const
+    virtual size_t get_reactants(std::vector<Molecule *> &reactants) const
     {
       reactants.push_back(m_rct1);
       reactants.push_back(m_rct2);

--- a/src/ExchangeReaction.h
+++ b/src/ExchangeReaction.h
@@ -64,14 +64,14 @@ namespace mesmer
     virtual Molecule *get_excessReactant(void) const { return m_rct2; };
 
     // Return products
-    virtual int get_products(std::vector<Molecule *> &products) const
+    virtual size_t get_products(std::vector<Molecule *> &products) const
     {
       products.push_back(m_pdt1);
       products.push_back(m_pdt2);
       return products.size();
     };
 
-    virtual int get_reactants(std::vector<Molecule *> &reactants) const
+    virtual size_t get_reactants(std::vector<Molecule *> &reactants) const
     {
       reactants.push_back(m_rct1);
       reactants.push_back(m_rct2);

--- a/src/IrreversibleExchangeReaction.h
+++ b/src/IrreversibleExchangeReaction.h
@@ -53,7 +53,7 @@ namespace mesmer
     virtual Molecule *get_excessReactant(void) const { return m_rct2; };
 
     // Return products
-    virtual int get_products(std::vector<Molecule *> &product) const
+    virtual size_t get_products(std::vector<Molecule *> &product) const
     {
       product.push_back(m_pdt1);
       if (m_pdt2) {
@@ -63,7 +63,7 @@ namespace mesmer
       return 1;
     };
 
-    virtual int get_reactants(std::vector<Molecule *> &reactants) const
+    virtual size_t get_reactants(std::vector<Molecule *> &reactants) const
     {
       reactants.push_back(m_rct1);
       reactants.push_back(m_rct2);

--- a/src/IrreversibleUnimolecularReaction.h
+++ b/src/IrreversibleUnimolecularReaction.h
@@ -66,7 +66,7 @@ namespace mesmer
 //X    void getPdtsCellDensityOfStates(std::vector<double> &cellDOS) ;
 
     // Return products
-    virtual int get_products(std::vector<Molecule *> &product) const
+    virtual size_t get_products(std::vector<Molecule *> &product) const
     {
       product.push_back(m_pdt1) ;
       if(m_pdt2){
@@ -80,7 +80,7 @@ namespace mesmer
       return 1;
     } ;
 
-    virtual int get_reactants(std::vector<Molecule *> &reactants) const
+    virtual size_t get_reactants(std::vector<Molecule *> &reactants) const
     {
       reactants.push_back(m_rct1);
       return 1;

--- a/src/IsomerizationReaction.h
+++ b/src/IsomerizationReaction.h
@@ -41,13 +41,13 @@ namespace mesmer
     };
 
     // Return products
-    virtual int get_products(std::vector<Molecule*>& product) const
+    virtual size_t get_products(std::vector<Molecule*>& product) const
     {
       product.push_back(m_pdt1);
       return 1;
     };
 
-    virtual int get_reactants(std::vector<Molecule*>& reactants) const
+    virtual size_t get_reactants(std::vector<Molecule*>& reactants) const
     {
       reactants.push_back(m_rct1);
       return 1;

--- a/src/Reaction.h
+++ b/src/Reaction.h
@@ -96,8 +96,8 @@ namespace mesmer
     ILT can be used in all reaction types if necessary. */
 
     // get products and reactants
-    virtual int get_products(std::vector<Molecule*>& product) const = 0;
-    virtual int get_reactants(std::vector<Molecule*>& reactants) const = 0;
+    virtual size_t get_products(std::vector<Molecule*>& product) const = 0;
+    virtual size_t get_reactants(std::vector<Molecule*>& reactants) const = 0;
 
     // get the reactant, which reacts in a first order or pseudo first order process
     virtual Molecule* get_reactant(void) const = 0;


### PR DESCRIPTION
Changes required by the Win64 build: int type replaced by size_t type in reaction class definitions.